### PR TITLE
v1.62

### DIFF
--- a/IdnTools/IdnTools.psd1
+++ b/IdnTools/IdnTools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'IdnTools.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.61'
+    ModuleVersion = '1.62'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -83,11 +83,13 @@
         "Set-IdnProvisioningPoliciesBySource"           ,
         "Update-IdnAccessProfileEntitlments"            ,
         "Remove-IdnAccessProfileEntitlments"            ,
+        "ConvertTo-IdnStandardRoleCriteria"             ,
         "Start-IdnSourceAccountAggregation"             ,
         "Get-IdnAccountAggregationStatus"               ,
         "Start-IdnEntitlementAggregation"               ,
         "Remove-IdnAccessProfileFromRole"               ,
         "Add-IdnAccessProfileEntitlments"               ,
+        "Get-IdnRoleMembershipCriteria"                 ,
         "Receive-IdnConfigExportStatus"                 ,
         "Import-IdnSourceEntitlements"                  ,
         "Invoke-IdnAccountAggregation"                  ,


### PR DESCRIPTION
Added support for converting Standard Role criteria to the Type, and getting Criteria only for Roles.  Update Membership function now supports updating Criteria as well as Identity Lists.  Fixed Bearer Token class so it will again load in WindowsPowerShell.